### PR TITLE
Rename references from `master` to `trunk`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ All notable changes to this project will be documented in this file, per [the Ke
 ## [1.0] - 2009-11-06
 - Initial plugin release :tada:
 
-[Unreleased]: https://github.com/10up/mce-table-buttons/compare/master...develop
+[Unreleased]: https://github.com/10up/mce-table-buttons/compare/trunk...develop
 [3.3]: https://github.com/10up/mce-table-buttons/commit/7b1f57e
 [3.2]: https://plugins.trac.wordpress.org/changeset/971857/
 [3.1]: https://plugins.trac.wordpress.org/changeset/924344/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ For more on how 10up writes and manages code, check out our [10up Engineering Be
 
 ## Workflow
 
-The `develop` branch is the development branch which means it contains the next version to be released.  `stable` contains the current latest release and `master` contains the corresponding stable development version.  Always work on the `develop` branch and open up PRs against `develop`.
+The `develop` branch is the development branch which means it contains the next version to be released.  `stable` contains the current latest release and `trunk` contains the corresponding stable development version.  Always work on the `develop` branch and open up PRs against `develop`.
 
 ## Release instructions
 
@@ -33,7 +33,7 @@ The `develop` branch is the development branch which means it contains the next 
 3. Changelog: Add/update the changelog in both `readme.txt` and `CHANGELOG.md`.
 4. New files: Check to be sure any new files/paths that are unnecessary in the production version are included in `.distignore`.
 5. Readme updates: Make any other readme changes as necessary.  `CHANGELOG.md` and `README.md` are geared toward GitHub and `readme.txt` contains WordPress.org-specific content.  The two are slightly different.
-6. Merge: Make a non-fast-forward merge from `develop` to `master` (`git checkout master && git merge --no-ff develop`).
+6. Merge: Make a non-fast-forward merge from `develop` to `trunk` (`git checkout trunk && git merge --no-ff develop`).
 7. Release: Create a [new release](https://github.com/10up/mce-table-buttons/releases/new), naming the tag and the release with the new version number. Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the closed issues on the milestone (e.g. `https://github.com/10up/mce-table-buttons/milestone/1?closed=1`).  Close the milestone.
 8. SVN: Wait for the [GitHub Action](https://github.com/10up/mce-table-buttons/actions) to finish deploying to the WordPress.org repository.  If all goes well, users with SVN commit access for that plugin will receive an emailed diff of changes.
 9. Check WordPress.org: Ensure that the changes are live on [https://wordpress.org/plugins/mce-table-buttons/](https://wordpress.org/plugins/mce-table-buttons/). This may take a few minutes.


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR builds on the creation of the `trunk` branch and changes previous references of `master` to `trunk`.  Once this PR is merged, we can delete the `master` branch.

### Alternate Designs

n/a

### Benefits

Removes `master` branch as part of this repo.

### Possible Drawbacks

none identified.

### Verification Process

Searched repo for references of `master`, renamed them to `trunk`.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
n/a